### PR TITLE
feat: Update Chat model and handler to use uint64 for IDs, and bump v…

### DIFF
--- a/internal/domain/chat.go
+++ b/internal/domain/chat.go
@@ -6,10 +6,10 @@ import (
 
 // Chat represents a conversation session
 type Chat struct {
-	ID             uint         `gorm:"primaryKey" json:"id"`
-	OrganizationID uint         `gorm:"not null;index" json:"organization_id"`
+	ID             uint64       `gorm:"primaryKey" json:"id"`
+	OrganizationID uint64       `gorm:"not null;index" json:"organization_id"`
 	Organization   Organization `gorm:"foreignKey:OrganizationID" json:"-"`
-	UserID         *uint        `json:"user_id,omitempty"` // Nullable for anonymous chats
+	UserID         *uint64      `json:"user_id,omitempty"` // Nullable for anonymous chats
 	User           *User        `gorm:"foreignKey:UserID" json:"-"`
 	Title          string       `gorm:"size:255" json:"title"`
 	Tags           string       `gorm:"type:jsonb" json:"tags"`     // JSON array of tags
@@ -22,24 +22,24 @@ type Chat struct {
 // ChatRepository defines the interface for chat data operations
 type ChatRepository interface {
 	Create(chat *Chat) error
-	FindByID(id uint) (*Chat, error)
-	FindByOrganizationID(orgID uint, limit, offset int) ([]Chat, error)
-	FindByUserID(userID uint, limit, offset int) ([]Chat, error)
+	FindByID(id uint64) (*Chat, error)
+	FindByOrganizationID(orgID uint64, limit, offset int) ([]Chat, error)
+	FindByUserID(userID uint64, limit, offset int) ([]Chat, error)
 	Update(chat *Chat) error
-	Delete(id uint) error
+	Delete(id uint64) error
 	// Advanced queries for analytics
-	CountByOrgIDAndDateRange(orgID uint, start, end time.Time) (int64, error)
-	GetTagStats(orgID uint) (map[string]int64, error)
+	CountByOrgIDAndDateRange(orgID uint64, start, end time.Time) (int64, error)
+	GetTagStats(orgID uint64) (map[string]int64, error)
 }
 
 // ChatService defines the interface for chat business logic
 type ChatService interface {
 	CreateChat(chat *Chat) error
-	GetByID(id uint) (*Chat, error)
-	GetByOrganizationID(orgID uint, limit, offset int) ([]Chat, error)
-	GetByUserID(userID uint, limit, offset int) ([]Chat, error)
+	GetByID(id uint64) (*Chat, error)
+	GetByOrganizationID(orgID uint64, limit, offset int) ([]Chat, error)
+	GetByUserID(userID uint64, limit, offset int) ([]Chat, error)
 	UpdateChat(chat *Chat) error
-	DeleteChat(id uint) error
+	DeleteChat(id uint64) error
 	// Analytics methods
-	GetChatStats(orgID uint, start, end time.Time) (map[string]interface{}, error)
+	GetChatStats(orgID uint64, start, end time.Time) (map[string]interface{}, error)
 }

--- a/internal/handler/chat_handler.go
+++ b/internal/handler/chat_handler.go
@@ -50,7 +50,7 @@ func (h *ChatHandler) CreateChat(c *gin.Context) {
 	var userID *uint64
 	userIDInterface, exists := c.Get("userID")
 	if exists {
-		uid := uint64(userIDInterface.(uint))
+		uid := userIDInterface.(uint64)
 		userID = &uid
 	} else {
 		// Use the userID from the request if provided

--- a/internal/handler/chat_handler.go
+++ b/internal/handler/chat_handler.go
@@ -66,7 +66,7 @@ func (h *ChatHandler) CreateChat(c *gin.Context) {
 
 	// Create chat object
 	chat := &domain.Chat{
-		OrganizationID: uint64(orgID.(uint)),
+		OrganizationID: organizationID,
 		UserID:         userID,
 		Title:          req.Title,
 		Tags:           string(tagsJSON),

--- a/internal/handler/chat_handler.go
+++ b/internal/handler/chat_handler.go
@@ -153,7 +153,7 @@ func (h *ChatHandler) ListChats(c *gin.Context) {
 	offset, _ := strconv.Atoi(c.DefaultQuery("offset", "0"))
 
 	// Get chats
-	chats, err := h.chatService.GetByOrganizationID(uint64(orgID.(uint)), limit, offset)
+	chats, err := h.chatService.GetByOrganizationID(orgID.(uint64), limit, offset)
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to list chats"})
 		return

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -3,7 +3,7 @@ package version
 // Version information
 var (
 	// Version is the current version of the application
-	Version = "0.1.1"
+	Version = "0.1.2"
 
 	// BuildTime is the time the binary was built
 	BuildTime = "unknown"


### PR DESCRIPTION
This pull request updates the `Chat` domain model, repository, and handler to use `uint64` for IDs instead of `uint`, ensuring compatibility with larger ID values. It also includes a version bump for the application. Below are the most important changes grouped by theme:

### ID Type Update to `uint64`:

* Updated `Chat` model fields `ID`, `OrganizationID`, and `UserID` to use `uint64` instead of `uint` in `internal/domain/chat.go`.
* Modified `ChatRepository` and `ChatService` interfaces to use `uint64` for all ID-related parameters in `internal/domain/chat.go`.
* Changed `CreateChatRequest` struct to use `uint64` for `UserID` in `internal/handler/chat_handler.go`.
* Updated all handler methods (e.g., `CreateChat`, `GetChat`, `ListChats`, `UpdateChat`, `DeleteChat`) to handle `uint64` for IDs and organization checks in `internal/handler/chat_handler.go`. [[1]](diffhunk://#diff-e352c931dbc93760049e170fe2466312a84460bae92a8c9e62b487998c248efeL50-R53) [[2]](diffhunk://#diff-e352c931dbc93760049e170fe2466312a84460bae92a8c9e62b487998c248efeL69-R69) [[3]](diffhunk://#diff-e352c931dbc93760049e170fe2466312a84460bae92a8c9e62b487998c248efeL104-R104) [[4]](diffhunk://#diff-e352c931dbc93760049e170fe2466312a84460bae92a8c9e62b487998c248efeL122-R122) [[5]](diffhunk://#diff-e352c931dbc93760049e170fe2466312a84460bae92a8c9e62b487998c248efeL156-R156) [[6]](diffhunk://#diff-e352c931dbc93760049e170fe2466312a84460bae92a8c9e62b487998c248efeL194-R194) [[7]](diffhunk://#diff-e352c931dbc93760049e170fe2466312a84460bae92a8c9e62b487998c248efeL212-R212) [[8]](diffhunk://#diff-e352c931dbc93760049e170fe2466312a84460bae92a8c9e62b487998c248efeL260-R260) [[9]](diffhunk://#diff-e352c931dbc93760049e170fe2466312a84460bae92a8c9e62b487998c248efeL278-R284)

### Version Update:

* Incremented the application version from `0.1.1` to `0.1.2` in `internal/version/version.go`.

Solves #5