### PR TITLE
Kjanat patch docker workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,6 +47,8 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
+      - run: echo ${{ secrets.COSIGN_PRIVATE_KEY }} > cosign.key
+
       - name: Import GPG key
         id: import_gpg
         uses: crazy-max/ghaction-import-gpg@v6
@@ -68,6 +70,8 @@ jobs:
           GPG_FINGERPRINT: ${{ steps.import_gpg.outputs.fingerprint }}
           DESCRIPTION: ${{ github.event.repository.description }}
           URL: ${{ github.server_url }}/${{ github.repository }}
+
+      - run: rm cosign.key
 
       - name: Upload assets
         uses: actions/upload-artifact@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,7 +47,9 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      - run: echo ${{ secrets.COSIGN_PRIVATE_KEY }} > cosign.key
+      - run: |
+          echo ${{ secrets.COSIGN_PRIVATE_KEY }} > cosign.key
+          chmod 600 cosign.key
 
       - name: Import GPG key
         id: import_gpg

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -61,19 +61,19 @@ nfpms:
 dockers:
   - dockerfile: .github/workflows/docker/Dockerfile.server
     goos: linux
-    goarch: amd64
+    goarch: [amd64, arm64]
     ids: [server]
     image_templates:
-      - ghcr.io/kjanat/chatlogger-api-go-server:latest
-      - ghcr.io/kjanat/chatlogger-api-go-server:{{.Tag}}
-      - ghcr.io/kjanat/chatlogger-api-go-server:{{.Major}}
-      - ghcr.io/kjanat/chatlogger-api-go-server:{{.Major}}.{{.Minor}}
-      - ghcr.io/kjanat/chatlogger-api-go-server:{{.Version}}
+      - ghcr.io/kjanat/chatlogger-api-server:latest
+      - ghcr.io/kjanat/chatlogger-api-server:{{.Tag}}
+      - ghcr.io/kjanat/chatlogger-api-server:{{.Major}}
+      - ghcr.io/kjanat/chatlogger-api-server:{{.Major}}.{{.Minor}}
+      - ghcr.io/kjanat/chatlogger-api-server:{{.Version}}
     build_flag_templates:
       - --pull
       - --label=org.opencontainers.image.title={{ .ProjectName }}
       - --label=org.opencontainers.image.description={{ .Env.DESCRIPTION }}
-      - --label=org.opencontainers.image.url={{ .Env.URL }}
+      - --label=org.opencontainers.image.url=https://github.com/users/kjanat/packages/container/package/chatlogger-api-server
       - --label=org.opencontainers.image.source={{ .Env.URL }}
       - --label=org.opencontainers.image.version={{.Version}}
       - --label=org.opencontainers.image.created={{ .Date }}
@@ -83,19 +83,19 @@ dockers:
   
   - dockerfile: .github/workflows/docker/Dockerfile.worker
     goos: linux
-    goarch: amd64
+    goarch: [amd64, arm64]
     ids: [worker]
     image_templates:
-      - ghcr.io/kjanat/chatlogger-api-go-worker:latest
-      - ghcr.io/kjanat/chatlogger-api-go-worker:{{.Tag}}
-      - ghcr.io/kjanat/chatlogger-api-go-worker:{{.Major}}
-      - ghcr.io/kjanat/chatlogger-api-go-worker:{{.Major}}.{{.Minor}}
-      - ghcr.io/kjanat/chatlogger-api-go-worker:{{.Version}}
+      - ghcr.io/kjanat/chatlogger-api-worker:latest
+      - ghcr.io/kjanat/chatlogger-api-worker:{{.Tag}}
+      - ghcr.io/kjanat/chatlogger-api-worker:{{.Major}}
+      - ghcr.io/kjanat/chatlogger-api-worker:{{.Major}}.{{.Minor}}
+      - ghcr.io/kjanat/chatlogger-api-worker:{{.Version}}
     build_flag_templates:
       - --pull
       - --label=org.opencontainers.image.title={{ .ProjectName }}
       - --label=org.opencontainers.image.description={{ .Env.DESCRIPTION }}
-      - --label=org.opencontainers.image.url={{ .Env.URL }}
+      - --label=org.opencontainers.image.url=https://github.com/users/kjanat/packages/container/package/chatlogger-api-worker
       - --label=org.opencontainers.image.source={{ .Env.URL }}
       - --label=org.opencontainers.image.version={{.Version}}
       - --label=org.opencontainers.image.created={{ .Date }}
@@ -106,7 +106,7 @@ dockers:
 docker_signs:
   - args:
       - "sign"
-      - "--key=${{ .Env.COSIGN_PRIVATE_KEY }}"
+      - "--key=cosign.key"
       - "--upload=true"
       - "${artifact}"
       - "--yes"


### PR DESCRIPTION
This pull request introduces several updates to the release workflow and Docker configurations to improve compatibility and security. The main changes include adding support for multiple architectures, renaming Docker image templates for consistency, and securely handling the signing key for Docker images.

### Workflow Updates:
* [`.github/workflows/release.yml`](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34R50-R51): Added steps to write the `COSIGN_PRIVATE_KEY` secret to a temporary `cosign.key` file before signing Docker images and to remove the file afterward for security. [[1]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34R50-R51) [[2]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34R74-R75)

### Docker Configuration Updates:
* [`.goreleaser.yaml`](diffhunk://#diff-7326b55c062b0f46fe9e39aace0a25f4515cf206040fb91a6fd2cae839f5e826L64-R76): Updated `dockers:` configuration to support both `amd64` and `arm64` architectures for the `server` and `worker` images. [[1]](diffhunk://#diff-7326b55c062b0f46fe9e39aace0a25f4515cf206040fb91a6fd2cae839f5e826L64-R76) [[2]](diffhunk://#diff-7326b55c062b0f46fe9e39aace0a25f4515cf206040fb91a6fd2cae839f5e826L86-R98)
* [`.goreleaser.yaml`](diffhunk://#diff-7326b55c062b0f46fe9e39aace0a25f4515cf206040fb91a6fd2cae839f5e826L64-R76): Renamed Docker image templates to remove the `-go` suffix for consistency with naming conventions. [[1]](diffhunk://#diff-7326b55c062b0f46fe9e39aace0a25f4515cf206040fb91a6fd2cae839f5e826L64-R76) [[2]](diffhunk://#diff-7326b55c062b0f46fe9e39aace0a25f4515cf206040fb91a6fd2cae839f5e826L86-R98)
* [`.goreleaser.yaml`](diffhunk://#diff-7326b55c062b0f46fe9e39aace0a25f4515cf206040fb91a6fd2cae839f5e826L109-R109): Updated the `docker_signs` configuration to use the temporary `cosign.key` file instead of referencing the `COSIGN_PRIVATE_KEY` environment variable directly.